### PR TITLE
Add link button to autofilled Minehut report

### DIFF
--- a/src/main/kotlin/team/azalea/maple/Database.kt
+++ b/src/main/kotlin/team/azalea/maple/Database.kt
@@ -34,5 +34,14 @@ object Database {
         return serverName ?: "Unknown Server"
     }
 
+    suspend fun getMinehutInfo(): Pair<String, String> {
+        val iron = getIron()
+        val minehutName = iron.prepare("SELECT value FROM server_settings WHERE key = 'minehut_name'")
+            .singleNullable<String>()
+        val minehutId = iron.prepare("SELECT value FROM server_settings WHERE key = 'minehut_id'")
+            .singleNullable<String>()
+        return Pair(minehutName ?: "Unknown Name", minehutId ?: "Unknown ID")
+    }
+
     fun getIron(): Iron = iron
 }

--- a/src/main/kotlin/team/azalea/maple/commands/Maple.kt
+++ b/src/main/kotlin/team/azalea/maple/commands/Maple.kt
@@ -44,3 +44,26 @@ fun setServerName(player: CommandSender, name: String) = maplePlugin.launch (map
 
     player.sendMessage("Server name set to $name")
 }
+
+fun setMinehutInfo(player: CommandSender, name: String, id: String) = maplePlugin.launch(maplePlugin.asyncDispatcher) {
+    if (!player.isOp) return@launch
+
+    val database = Database.getIron()
+
+    try {
+        suspend fun setServerSetting(key: String, value: String) {
+            database.prepare(" INSERT OR REPLACE INTO server_settings (key, value) VALUES (:key, :value)", bind {
+                "key" to key
+                "value" to value
+            })
+        }
+
+        setServerSetting("minehut_name", name)
+        setServerSetting("minehut_id", id)
+
+        player.sendMessage("Server ID set to $id, server name set to $name")
+    } catch (e: Exception) {
+        player.sendMessage("An error occurred while updating server settings.")
+        e.printStackTrace()
+    }
+}

--- a/src/main/kotlin/team/azalea/maple/punishments/MinehutReportInfo.kt
+++ b/src/main/kotlin/team/azalea/maple/punishments/MinehutReportInfo.kt
@@ -1,0 +1,44 @@
+package team.azalea.maple.punishments
+
+import team.azalea.maple.util.formatDateWithSeconds
+import java.net.URLEncoder
+import java.time.Instant
+
+private const val SUPPORT_FORM_URL = "https://support.minehut.com/hc/en-us/requests/new"
+
+private const val SUBJECT_FIELD = "tf_subject"
+private const val DESCRIPTION_FIELD = "tf_description"
+private const val CATEGORY_FIELD = "tf_27062997154195"
+private const val REPORT_TYPE_FIELD = "tf_27063229498259"
+private const val MODERATOR_USERNAME_FIELD = "tf_27063020886291"
+private const val REPORTED_USERNAME_FIELD = "tf_31915142821523"
+private const val SERVER_NAME_FIELD = "tf_27062989544851"
+private const val SERVER_ID_FIELD = "tf_27063041501203"
+
+fun getMinehutReportLink(punishment: Punishment, timestamp: Instant): String {
+    val shortReason = getReasonInfo(punishment.reason).first
+    val formattedTimestamp = formatDateWithSeconds(timestamp)
+
+    val parameters = mutableMapOf(
+        SUBJECT_FIELD to "Reporting Player",
+        CATEGORY_FIELD to "reports_appeals",
+        REPORT_TYPE_FIELD to "report_user",
+        MODERATOR_USERNAME_FIELD to punishment.moderator.name,
+        REPORTED_USERNAME_FIELD to punishment.player.name,
+        DESCRIPTION_FIELD to """
+            This player is being reported for ${shortReason.lowercase()}.
+            They have already been punished on our server at $formattedTimestamp.
+        """.trimIndent(),
+    )
+
+    val queryBuilder = StringBuilder("?")
+    parameters.forEach { (key, value) ->
+        if (queryBuilder.last() != '?') {
+            queryBuilder.append("&")
+        }
+        val encodedValue = URLEncoder.encode(value, Charsets.UTF_8)
+        queryBuilder.append("$key=$encodedValue")
+    }
+
+    return SUPPORT_FORM_URL + queryBuilder.toString()
+}

--- a/src/main/kotlin/team/azalea/maple/punishments/MinehutReportInfo.kt
+++ b/src/main/kotlin/team/azalea/maple/punishments/MinehutReportInfo.kt
@@ -1,5 +1,6 @@
 package team.azalea.maple.punishments
 
+import team.azalea.maple.Database
 import team.azalea.maple.util.formatDateWithSeconds
 import java.net.URLEncoder
 import java.time.Instant
@@ -15,9 +16,10 @@ private const val REPORTED_USERNAME_FIELD = "tf_31915142821523"
 private const val SERVER_NAME_FIELD = "tf_27062989544851"
 private const val SERVER_ID_FIELD = "tf_27063041501203"
 
-fun getMinehutReportLink(punishment: Punishment, timestamp: Instant): String {
+suspend fun getMinehutReportLink(punishment: Punishment, timestamp: Instant): String {
     val shortReason = getReasonInfo(punishment.reason).first
     val formattedTimestamp = formatDateWithSeconds(timestamp)
+    val minehutInfo = Database.getMinehutInfo()
 
     val parameters = mutableMapOf(
         SUBJECT_FIELD to "Reporting Player",
@@ -27,8 +29,10 @@ fun getMinehutReportLink(punishment: Punishment, timestamp: Instant): String {
         REPORTED_USERNAME_FIELD to punishment.player.name,
         DESCRIPTION_FIELD to """
             This player is being reported for ${shortReason.lowercase()}.
-            They have already been punished on our server at $formattedTimestamp.
+            They have already been punished on our server at $formattedTimestamp UTC.
         """.trimIndent(),
+        SERVER_NAME_FIELD to minehutInfo.first,
+        SERVER_ID_FIELD to minehutInfo.second,
     )
 
     val queryBuilder = StringBuilder("?")

--- a/src/main/kotlin/team/azalea/maple/punishments/Punishment.kt
+++ b/src/main/kotlin/team/azalea/maple/punishments/Punishment.kt
@@ -10,6 +10,7 @@ import gg.ingot.iron.annotations.Column
 import gg.ingot.iron.annotations.Model
 import gg.ingot.iron.bindings.Bindings
 import gg.ingot.iron.strategies.NamingStrategy
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.entities.MessageEmbed
@@ -367,14 +368,17 @@ data class Punishment(
                 logEmbed.addField(MessageEmbed.Field("Notes", info.notes, true))
             }
 
-            val minehutReportUrl = getMinehutReportLink(this, Instant.now())
+            // yes this is run blocking, but it shouldn't rly matter
+            runBlocking {
+                val minehutReportUrl = getMinehutReportLink(info, Instant.now())
 
-            val messageCreate = MessageCreateBuilder()
-                .setEmbeds(logEmbed.build())
-                .addComponents(ActionRow.of(Button.link(minehutReportUrl, "Create Report")))
-                .build()
+                val messageCreate = MessageCreateBuilder()
+                    .setEmbeds(logEmbed.build())
+                    .addComponents(ActionRow.of(Button.link(minehutReportUrl, "Create Report")))
+                    .build()
 
-            discordLogChannel.sendMessage(messageCreate).queue()
+                discordLogChannel.sendMessage(messageCreate).queue()
+            }
         }
     }
 

--- a/src/main/kotlin/team/azalea/maple/punishments/Punishment.kt
+++ b/src/main/kotlin/team/azalea/maple/punishments/Punishment.kt
@@ -13,6 +13,9 @@ import gg.ingot.iron.strategies.NamingStrategy
 import kotlinx.coroutines.withContext
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.interactions.components.ActionRow
+import net.dv8tion.jda.api.interactions.components.buttons.Button
+import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder
 import net.kyori.adventure.text.Component
 import org.bukkit.Bukkit
 import org.bukkit.entity.Player
@@ -364,7 +367,14 @@ data class Punishment(
                 logEmbed.addField(MessageEmbed.Field("Notes", info.notes, true))
             }
 
-            discordLogChannel.sendMessageEmbeds(logEmbed.build()).queue()
+            val minehutReportUrl = getMinehutReportLink(this, Instant.now())
+
+            val messageCreate = MessageCreateBuilder()
+                .setEmbeds(logEmbed.build())
+                .addComponents(ActionRow.of(Button.link(minehutReportUrl, "Create Report")))
+                .build()
+
+            discordLogChannel.sendMessage(messageCreate).queue()
         }
     }
 

--- a/src/main/kotlin/team/azalea/maple/util/GeneralUtil.kt
+++ b/src/main/kotlin/team/azalea/maple/util/GeneralUtil.kt
@@ -10,3 +10,10 @@ fun formatDate(instant: Instant): String {
         .withZone(ZoneId.systemDefault())
     return formatter.format(instant)
 }
+
+fun formatDateWithSeconds(instant: Instant): String {
+    if(instant == Instant.MAX) return "Never"
+    val formatter = DateTimeFormatter.ofPattern("MM/dd/uuuu HH:mm:ss")
+        .withZone(ZoneId.systemDefault())
+    return formatter.format(instant)
+}

--- a/src/main/kotlin/team/azalea/maple/util/GeneralUtil.kt
+++ b/src/main/kotlin/team/azalea/maple/util/GeneralUtil.kt
@@ -15,12 +15,14 @@ fun formatDate(instant: Instant): String {
 }
 
 fun formatDateWithSeconds(instant: Instant): String {
-    if(instant == Instant.MAX) return "Never"
+    if (instant == Instant.MAX) return "Never"
     val formatter = DateTimeFormatter.ofPattern("MM/dd/uuuu HH:mm:ss")
         .withZone(ZoneId.systemDefault())
     return formatter.format(instant)
+}
 
 fun infinity(code: Consumer<BukkitTask>, delay: Int) {
     maplePlugin.server.scheduler.runTaskTimer(maplePlugin, { it: BukkitTask ->
         code.accept(it)
-}, 0, delay.toLong())
+    }, 0, delay.toLong())
+}


### PR DESCRIPTION
Adds a button to the punishment log message that links to a Minehut report with most fields pre-filled for you.
If we want, we can also autofill the server name and ID fields, but that will take extra work.

(Untested, oops)

Resolves AZALEA-82.